### PR TITLE
Fix GitHub pages base path

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,6 @@
     <div id="root"></div>
     <!-- IMPORTANT: DO NOT REMOVE THIS SCRIPT TAG OR THIS VERY COMMENT! -->
     <script src="https://cdn.gpteng.co/gptengineer.js" type="module"></script>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="./src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 // נתב האפליקציה
 const AppRouter = () => {
   return (
-    <Router>
+    <Router basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route path="/auth" element={<Auth />} />
         <Route 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? '/image-insight-reports/' : '/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- ensure paths work on GitHub Pages by using a relative base path
- load main script relative to index
- router now uses basename to match URLs under the repository prefix

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840473227c48326b3326fd993988f33